### PR TITLE
Fix some typos in the README and example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ![icon](./glfw-icon.png) GLFW
 
-This is a Ruby C-extension that for the excellent [GLFW](https://github.com/glfw/glfw) library. Unlike other bindings, this gem goes beyond just providing a 1:1 wrapper of the functions, and has been organized to be used in a more object-oriented, Ruby way.
+This is a Ruby C-extension for the excellent [GLFW](https://github.com/glfw/glfw) library. Unlike other bindings, this gem goes beyond just providing a 1:1 wrapper of the functions, and has been organized to be used in a more object-oriented, Ruby way.
 
 ## Installation
 
-For Windows user, you can download the pre-built binaries at [here](https://www.glfw.org/download.html) for your target architecture, or both. Place these within the their respective folders withing the `ext/glfw/` directory.
+For Windows users, you can download the pre-built binaries [here](https://www.glfw.org/download.html) for your target architecture, or both. Place these within the their respective folders withing the `ext/glfw/` directory.
 
 For Unix users, simply have GLFW installed globally, and it will be found and linked against during the build process.
 
@@ -24,14 +24,14 @@ Open a terminal/command prompt in the base directory:
 
 ### Window Creation
 
-At is simplest, to create a platform-specific window with an OpenGL context requires very little code.
+At its simplest, to create a platform-specific window with an OpenGL context requires very little code.
 
 ```ruby
 GLFW::Window.new(800, 600, "Hello, World!") do |window|
 
   until window.closing?
     GLFW.poll_events
-    GLFW.swap_buffers
+    window.swap_buffers
     # Your rendering code goes here
   end
 end
@@ -44,12 +44,12 @@ You will likely want to fine-tune the created context to what your application r
 GLFW.init
 
 # Load default window hints. This will reset any previous hints given
-GLFW.default_hints
+GLFW.load_default_hints
 
 # Window will be NOT be decorated (title, border, close widget, etc)
 GLFW.hint(GLFW::HINT_DECORATED, false)
 
-# Specifiy MINIMUM required OpenGL version
+# Specify MINIMUM required OpenGL version
 GLFW.hint(GLFW::HINT_CONTEXT_VERSION_MAJOR, 3)
 GLFW.hint(GLFW::HINT_CONTEXT_VERSION_MAJOR, 0)
 ```
@@ -58,7 +58,7 @@ All constants for creation hints are prefixed with `HINT`.
 
 ### Callbacks
 
-GLFW offers a high-level of control of the application window, including callbacks for nearly every relevant system event that effects the window (see documentation for what all callbacks are available). By default, most of these callbacks are disabled, and need enabled with a method call to have them fired. This for performance reasons, as it is inefficient to have them all being invoked if they are not going to be used.
+GLFW offers a high-level of control of the application window, including callbacks for nearly every relevant system event that effects the window (see documentation for what all callbacks are available). By default, most of these callbacks are disabled, and need to be enabled with a method call to have them fired. This is for performance reasons, as it is inefficient to have them all being invoked if they are not going to be used.
 
 To enable a callback:
 
@@ -66,7 +66,7 @@ To enable a callback:
 window.enable_callback(GLFW::CB_RESIZED, true)
 ```
 
-You then have two options; to either alias the `GLFW::Window` class for the relevant callback, or more commonly is to create your own class the inherits from `GLFW::Window`.
+You then have two options; to either alias the `GLFW::Window` class for the relevant callback, or more commonly to create your own class that inherits from `GLFW::Window`.
 
 ```ruby
 class MyGame < GLFW::Window
@@ -78,7 +78,7 @@ class MyGame < GLFW::Window
 
   # This method will be invoked when the window is resized.
   def resized(width, hight)
-    # Your code goes here. 
+    # Your code goes here.
     # The "width/height" arguments passed are the new size
   end
 end


### PR DESCRIPTION
I tried all the code examples in the README and fixed the two lines of code that were incorrect.

Also fixed up some typos in the README text that stuck out at me.
